### PR TITLE
Should install rails from gems

### DIFF
--- a/puppet/manifests/default.pp
+++ b/puppet/manifests/default.pp
@@ -139,3 +139,8 @@ exec { "${as_vagrant} 'gem install bundler --no-rdoc --no-ri'":
   creates => "${home}/.rvm/bin/bundle",
   require => Exec['install_ruby']
 }
+
+exec { "${as_vagrant} 'gem install rails --no-rdoc --no-ri'":
+  creates => "${home}/.rvm/bin/rails",
+  require => Exec['install_ruby']
+}


### PR DESCRIPTION
The vagrant recipe should probably install rails. I believe the original this is based on, rails-dev-box, installs rails by cloning a rails fork directly, but we should be fine with gem-based install.
